### PR TITLE
fix regression added in PR seperated the mesh code

### DIFF
--- a/web/lifecast_res/LdiFthetaMesh.js
+++ b/web/lifecast_res/LdiFthetaMesh.js
@@ -25,14 +25,17 @@ export class LdiFthetaMesh extends THREE.Object3D {
     num_patches_not_culled = 0; // Used for performance stats (want to know how many patches are being draw in various scenes).
     ftheta_scale = null
 
-    constructor(_format, is_chrome, photo_mode, _metadata_url, _decode_12bit, texture) {
+    constructor(_format, is_chrome, photo_mode, _metadata_url, _decode_12bit, texture, _ftheta_scale = null) {
 
         super()
 
-        if (_format == "ldi2") this.ftheta_scale = 1.2;
-        else if (_format == "ldi3") this.ftheta_scale = 1.15;
-        else { console.log("Error, unknown format: ", _format); }
-
+        if (_ftheta_scale == null) {
+            if (_format == "ldi2") this.ftheta_scale = 1.2;
+            else if (_format == "ldi3") this.ftheta_scale = 1.15;
+            else { console.log("Error, unknown format: ", _format); }
+        } else {
+            this.ftheta_scale = _ftheta_scale
+        }
         console.log("_format=", _format);
         console.log("_ftheta_scale=", this.ftheta_scale);
 

--- a/web/lifecast_res/LifecastVideoPlayer9.js
+++ b/web/lifecast_res/LifecastVideoPlayer9.js
@@ -545,7 +545,7 @@ function render() {
     resetVRToCenter();
   }
 
-  //console.log("num_patches_not_culled=", num_patches_not_culled);
+  // console.log("num_patches_not_culled=", ldi_ftheta_mesh.num_patches_not_culled);
 }
 
 function animate() {
@@ -617,11 +617,11 @@ function convertRotationMatrixLifecastToThreeJs(R) {
 function rotateFthetaMeshBoundingSpheres(R) {
   // Update bounding spheres for patches.
   var Rm = new THREE.Matrix3().fromArray(R);
-  for (var p of ftheta_fg_geoms) {
+  for (var p of ldi_ftheta_mesh.ftheta_fg_geoms) {
     p.boundingSphere.center.copy(p.originalBoundingSphere.center);
     p.boundingSphere.center.applyMatrix3(Rm);
   }
-  for (var p of ftheta_bg_geoms) {
+  for (var p of ldi_ftheta_mesh.ftheta_bg_geoms) {
     p.boundingSphere.center.copy(p.originalBoundingSphere.center);
     p.boundingSphere.center.applyMatrix3(Rm);
   }
@@ -905,7 +905,7 @@ export function init({
   world_group = new THREE.Group();
   scene.add(world_group);
 
-  ldi_ftheta_mesh = new LdiFthetaMesh(_format, is_chrome, photo_mode, _metadata_url, _decode_12bit, texture)
+  ldi_ftheta_mesh = new LdiFthetaMesh(_format, is_chrome, photo_mode, _metadata_url, _decode_12bit, texture, _ftheta_scale)
   world_group.add(ldi_ftheta_mesh)
 
   // Make the point sprite for VR buttons.


### PR DESCRIPTION
Fix some regression added in my PR https://github.com/fbriggs/lifecast_public/pull/12

- does ignore anymore `_ftheta_scale` coming from `LifecastVideoPlayer`
- `rotateFthetaMeshBoundingSpheres` must still access `ftheta_fg_geoms`

I tested ldi.html and index.html in Chrome/Safari iPhone 12; Ch OQ2; Ch Android; Ch PC.