### PR TITLE
autoplay muted

### DIFF
--- a/web/lifecast_res/HelpGetVR11.js
+++ b/web/lifecast_res/HelpGetVR11.js
@@ -25,7 +25,6 @@ THE SOFTWARE.
 
 class HelpGetVR {
   static createBanner(renderer, enter_xr_button_title, exit_xr_button_title) {
-
     var banner = document.createElement( 'div' );
 
     function showEnterVR() {

--- a/web/lifecast_res/LifecastVideoPlayer11.js
+++ b/web/lifecast_res/LifecastVideoPlayer11.js
@@ -44,7 +44,7 @@ const CubeFace = {
 
 const gesture_control = new GestureControlModule();
 
-let enable_debug_text = false; // Turn this on if you want to use debugLog() or setDebugText().
+let enable_debug_text = true; // Turn this on if you want to use debugLog() or setDebugText().
 let debug_text_mesh, debug_text_div;
 let debug_log = "";
 let debug_msg_count = 0;
@@ -764,7 +764,6 @@ function createFingertipIndicator(color) {
   return sphere;
 }
 
-/*
 export function updateEmbedControls(
     _fov, _x, _y, _z, _u, _v,
     _anim_fov, _anim_x, _anim_y, _anim_z, _anim_u, _anim_v,
@@ -791,7 +790,6 @@ export function updateEmbedControls(
   onWindowResize();
   playVideoIfReady();
 }
-*/
 
 export function init({
   _format = "ldi2", // ldi2 or ldi3

--- a/web/lifecast_res/LifecastVideoPlayer11.js
+++ b/web/lifecast_res/LifecastVideoPlayer11.js
@@ -44,7 +44,7 @@ const CubeFace = {
 
 const gesture_control = new GestureControlModule();
 
-let enable_debug_text = true; // Turn this on if you want to use debugLog() or setDebugText().
+let enable_debug_text = false; // Turn this on if you want to use debugLog() or setDebugText().
 let debug_text_mesh, debug_text_div;
 let debug_log = "";
 let debug_msg_count = 0;

--- a/web/lifecast_res/LifecastVideoPlayer11.js
+++ b/web/lifecast_res/LifecastVideoPlayer11.js
@@ -801,7 +801,7 @@ export function init({
   _force_recenter_frames = [], // (If supported), VR coordinate frame is reset on these frames.
   _embed_in_div = "",
   _cam_mode="default",
-  _hfov = 80,
+  _vfov = 80,
   _vscroll_bias = 0.0,
   _framerate = 30,
   _ftheta_scale = null,
@@ -812,7 +812,9 @@ export function init({
   _create_button_url = "",
   _decode_12bit = true,
   _enable_pinch_world_drag = false,
-  _looking_glass_config = null
+  _looking_glass_config = null,
+  _autoplay_muted = false, // If this is a video, try to start playing immediately (muting is required)
+  _loop = false
 }={}) {
   if (_media_url.includes("ldi3") || _media_url_oculus.includes("ldi3") || _media_url_mobile.includes("ldi3")) {
     _format = "ldi3";
@@ -839,12 +841,12 @@ export function init({
 
   if (is_ios) {
     if (window.innerHeight > window.innerWidth) { // portrait
-      _hfov = 120;
+      _vfov = 120;
     } else {
-      _hfov = 90;
+      _vfov = 90;
     }
   }
-  anim_fov_offset = _hfov;
+  anim_fov_offset = _vfov;
 
   if (slideshow.length > 0) {
     photo_mode = true;
@@ -918,6 +920,7 @@ export function init({
     video.setAttribute("crossorigin", "anonymous");
     video.setAttribute("type", "video/mp4");
     video.setAttribute("playsinline", true);
+    video.loop = _loop;
 
     // Select the best URL based on browser
     let best_media_url = _media_url;
@@ -940,6 +943,12 @@ export function init({
     video.addEventListener("error",     function() {
       document.documentElement.innerHTML = "Error loading video URL: "  + best_media_url;
     });
+
+    if(_autoplay_muted) {
+      video.muted = true;
+      video.play();
+    }
+
     document.body.appendChild(video);
 
     var frame_callback = function() {};
@@ -980,7 +989,7 @@ export function init({
 
   makeNonVrControls();
 
-  camera = new THREE.PerspectiveCamera(_hfov, window.innerWidth / window.innerHeight, 0.1, 110);
+  camera = new THREE.PerspectiveCamera(_vfov, window.innerWidth / window.innerHeight, 0.1, 110);
 
   scene = new THREE.Scene();
   scene.background = new THREE.Color(0x000000);
@@ -1248,11 +1257,11 @@ export function init({
       let q = diff_orientation_a + mobile_drag_u;
 
       if (window.innerHeight > window.innerWidth) { // portrait
-        _hfov = 120;
+        _vfov = 120;
       } else {
-        _hfov = 90;
+        _vfov = 90;
       }
-      camera.fov = _hfov;
+      camera.fov = _vfov;
       camera.updateProjectionMatrix();
 
       camera.position.set(-q * 1.0, p * 1.0, 0.0);
@@ -1297,6 +1306,11 @@ export function init({
     // Start the video playing automatically if the user enters VR.
     if (!photo_mode) {
       debugLog("playVideoIfReady in sessionstart");
+
+      // Unmute for immersive experience!
+      if (_autoplay_muted) {
+        video.muted = false;
+      }
 
       playVideoIfReady();
     }

--- a/web/lifecast_res/LifecastVideoPlayer11.js
+++ b/web/lifecast_res/LifecastVideoPlayer11.js
@@ -764,6 +764,7 @@ function createFingertipIndicator(color) {
   return sphere;
 }
 
+/*
 export function updateEmbedControls(
     _fov, _x, _y, _z, _u, _v,
     _anim_fov, _anim_x, _anim_y, _anim_z, _anim_u, _anim_v,
@@ -790,6 +791,7 @@ export function updateEmbedControls(
   onWindowResize();
   playVideoIfReady();
 }
+*/
 
 export function init({
   _format = "ldi2", // ldi2 or ldi3
@@ -1026,6 +1028,8 @@ export function init({
     debug_text_div.style.fontFamily = 'Arial';
     debug_text_div.style.fontSize = '14px';
     debug_text_div.style.padding = '10px';
+    debug_text_div.style.color = 'black';
+
     // We have to add the div to the document.body or it wont render.
     // But to keep it out of view (in 2D), move it far offscreen.
     debug_text_div.style.position = 'absolute';
@@ -1305,14 +1309,12 @@ export function init({
 
     // Start the video playing automatically if the user enters VR.
     if (!photo_mode) {
-      debugLog("playVideoIfReady in sessionstart");
+      playVideoIfReady();
 
       // Unmute for immersive experience!
       if (_autoplay_muted) {
         video.muted = false;
       }
-
-      playVideoIfReady();
     }
 
     // When we enter VR, toggle on the VR-only 3d buttons.


### PR DESCRIPTION
despite my best efforts I cannot get VisionPro to auto-play a video when entering an immersive session (it still requires some input like a pinch to restart the video playing). This seems to be a common issue for WebXR video on VP currently, and none of the known workarounds seem to be effective here. Hopefully users will figure it out!