### PR TITLE
fewer draw calls, same # of triangles

### DIFF
--- a/web/lifecast_res/LdiFthetaMesh11.js
+++ b/web/lifecast_res/LdiFthetaMesh11.js
@@ -79,9 +79,9 @@ export class LdiFthetaMesh extends THREE.Object3D {
 
         if (_format == "ldi3") {
             const inflation = 3.0;
-            this.makeFthetaMesh(_format, ldi3_layer0_material, 32, 16, 0, inflation);
-            this.makeFthetaMesh(_format, ldi3_layer1_material, 32, 16, 1, inflation);
-            this.makeFthetaMesh(_format, ldi3_layer2_material, 32, 16, 2, inflation);
+            this.makeFthetaMesh(_format, ldi3_layer0_material, 128, 4, 0, inflation);
+            this.makeFthetaMesh(_format, ldi3_layer1_material, 128, 4, 1, inflation);
+            this.makeFthetaMesh(_format, ldi3_layer2_material, 128, 4, 2, inflation);
         } else {
             console.log("Unrecognized format: ", _format);
         }


### PR DESCRIPTION
we used to divide the mesh up into many patches for frustum culling, but now we dont, so there isn't as much benefit.
it doesn't work to put all of the triangles in one patch (its too many triangles apparently).
but we can get a little optimization by having fewer patches and more triangles per patch -> less draw calls and CPU overhead