### PR TITLE
Don't reset position on play/pause toggle

### DIFF
--- a/web/lifecast_res/LifecastVideoPlayer11.js
+++ b/web/lifecast_res/LifecastVideoPlayer11.js
@@ -336,7 +336,6 @@ function toggleVideoPlayPause() {
     video_is_buffering = false;
     video.pause();
   } else {
-    resetVRToCenter();
     playVideoIfReady();
   }
 }


### PR DESCRIPTION
The `resetVRToCenter` on `toggleVideoPlayPause` has the side-effect of sometimes jerking the video back to a translation and scale other than what you would expect, if you're using gesture controls. (I think this is because of unintentional pinch events often being interpreted as "play/pause"). It's much smoother and more usable if this reset does not happen.

This is the case for viewing looping LDI3 holograms in immersive AR mode, at least.