### PR TITLE
render tweaks- accompanies nerf engine changes

### DIFF
--- a/web/lifecast_res/LdiFthetaMesh11.js
+++ b/web/lifecast_res/LdiFthetaMesh11.js
@@ -51,7 +51,7 @@ export class LdiFthetaMesh extends THREE.Object3D {
             transparent: _transparent_bg,
             wireframe: false
         });
-        ldi3_layer0_material.side = THREE.DoubleSide;
+        ldi3_layer0_material.side = THREE.BackSide;
         ldi3_layer0_material.depthFunc = THREE.LessDepth;
 
         const ldi3_layer1_material = this.ldi3_layer1_material = new THREE.ShaderMaterial({
@@ -63,7 +63,7 @@ export class LdiFthetaMesh extends THREE.Object3D {
             transparent: true,
             wireframe: false
         });
-        ldi3_layer1_material.side = THREE.DoubleSide;
+        ldi3_layer1_material.side = THREE.BackSide;
         ldi3_layer1_material.depthFunc = THREE.LessEqualDepth;
 
         const ldi3_layer2_material = this.ldi3_layer2_material = new THREE.ShaderMaterial({
@@ -75,7 +75,7 @@ export class LdiFthetaMesh extends THREE.Object3D {
             transparent: true,
             wireframe: false
         });
-        ldi3_layer2_material.side = THREE.DoubleSide;
+        ldi3_layer2_material.side = THREE.BackSide;
         ldi3_layer2_material.depthFunc = THREE.LessEqualDepth;
 
         if (_format == "ldi3") {

--- a/web/lifecast_res/LifecastVideoPlayerShaders11.js
+++ b/web/lifecast_res/LifecastVideoPlayerShaders11.js
@@ -136,6 +136,7 @@ void main() {
 
   vec3 rgb = texture2D(uTexture, texture_uv).rgb;
   float a = texture2D(uTexture, alpha_uv).r;
+  if (a < 0.1) discard;
 
   gl_FragColor = vec4(rgb, a);
 }
@@ -173,6 +174,7 @@ void main() {
 #if defined(TRANSPARENT_BG)
   vec2 alpha_uv   = vec2(vUv.s * 0.33333 + 0.66666, vUv.t * 0.33333);
   float a = texture2D(uTexture, alpha_uv).r;
+  if (a < 0.1) discard;
   gl_FragColor = vec4(texture2D(uTexture, texture_uv).rgb, a);
 #else
   gl_FragColor = texture2D(uTexture, texture_uv);


### PR DESCRIPTION
* Discard fragments with very low alpha to prevent messing up depth buffer
* Render meshes only one-sided to prevent back-facing triangles from messing up depth buffer (they shouldn't be visible anyway)