### PR TITLE
do not exceed triangle limit on quest pro

### DIFF
--- a/web/lifecast_res/LdiFthetaMesh11.js
+++ b/web/lifecast_res/LdiFthetaMesh11.js
@@ -82,7 +82,7 @@ export class LdiFthetaMesh extends THREE.Object3D {
             const inflation = 3.0;
             this.makeFthetaMesh(_format, ldi3_layer0_material, 128, 4, 0, inflation);
             this.makeFthetaMesh(_format, ldi3_layer1_material, 128, 4, 1, inflation);
-            this.makeFthetaMesh(_format, ldi3_layer2_material, 128, 4, 2, inflation);
+            this.makeFthetaMesh(_format, ldi3_layer2_material, 96, 4, 2, inflation); // HACK: a few less triangles here to give some overhead on Quest Pro to not exceed triangle limit when displaying extra UI elements.
         } else {
             console.log("Unrecognized format: ", _format);
         }

--- a/web/lifecast_res/LifecastVideoPlayer11.js
+++ b/web/lifecast_res/LifecastVideoPlayer11.js
@@ -490,14 +490,14 @@ function render() {
     setVisibilityForLayerMeshes(0, false);
     setVisibilityForLayerMeshes(1, true);
     setVisibilityForLayerMeshes(2, false);
-    renderer.clearDepth(); // TODO: not sure if we still need this with normalized depth
+    //renderer.clearDepth(); // TODO: not sure if we still need this with normalized depth
     renderer.render(scene, camera);
   }
   if (toggle_layer2) {
     setVisibilityForLayerMeshes(0, false);
     setVisibilityForLayerMeshes(1, false);
     setVisibilityForLayerMeshes(2, true);
-    renderer.clearDepth(); // TODO: not sure if we still need this with normalized depth
+    //renderer.clearDepth(); // TODO: not sure if we still need this with normalized depth
     renderer.render(scene, camera);
   }
 
@@ -930,8 +930,8 @@ export function init({
   });
   renderer.autoClear = false;
   renderer.autoClearColor = false;
-  renderer.autoClearDepth = false;
-  renderer.autoClearStencil = true; // HACK: this is to prevent THREE.js from causing an error when it attempts to clear with no bits set (despite autoClear=false).
+  renderer.autoClearDepth = true;
+  renderer.autoClearStencil = false;
   renderer.setPixelRatio(window.devicePixelRatio);
   renderer.xr.enabled = true;
   if (_transparent_bg) {


### PR DESCRIPTION
It seems like when the buffering icon is visible in 3D, this exceeds the quest pro's drawing limits and the mesh disappears for a frame or two, which is very painful in VR. This PR reduces the triangle count on the bottom layer to avoid this (although it can still happen while the 2D browser window is open at the same time as the immersive view). I don't want to go too far on lowest-common denominator stuff here (this isn't necessary for Vision Pro or Quest 3). It would be great if we could detect which device it is and adjust the settings accordingly (maybe in future). 

also in this PR- adjustments to buffer clearing so the interface layer doesn't share a z buffer with the last LDI layer (and always draws on top of it).