### PR TITLE
Add _min_fov parameter to fix FOV on mobile devices

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -22,6 +22,7 @@
     //_embed_in_div: "",
     //_cam_mode: "default", // default, orbit
     //_vfov: 80,  // vertical field of view
+    //_min_fov: 60,  // vertical field of view will scale up such that the lesser of hfov and vfov is this value
     //_lock_position: false, // If true, do not allow camera motion
     //_autoplay_muted: true, // If this is a video, try to start playing immediately (muting is required)
     //_loop: true,  // If true, loop video

--- a/web/lifecast_res/LifecastVideoPlayer11.js
+++ b/web/lifecast_res/LifecastVideoPlayer11.js
@@ -754,6 +754,7 @@ export function init({
   _embed_in_div = "",
   _cam_mode="default",
   _vfov = 80,
+  _min_fov = null,
   _ftheta_scale = null,
   _lock_position = false,
   _decode_12bit = true,
@@ -870,7 +871,12 @@ export function init({
 
   makeNonVrControls();
 
-  camera = new THREE.PerspectiveCamera(_vfov, window.innerWidth / window.innerHeight, 0.1, 110);
+  let aspect_ratio = window.innerWidth / window.innerHeight;
+  if (_min_fov && _vfov * aspect_ratio < _min_fov) {
+    // For tall aspect ratios, ensure a minimum FOV
+    _vfov = _min_fov / aspect_ratio;
+  }
+  camera = new THREE.PerspectiveCamera(_vfov, aspect_ratio, 0.1, 110);
 
   scene = new THREE.Scene();
   scene.background = new THREE.Color(0x000000);


### PR DESCRIPTION
This adds a new parameter `_min_fov` to the player, intended to fix some of the extreme differences between desktop and mobile FOV in 2D mode.

Setting `_vfov = 80` as we currently do and `_min_fov = 60` seems to me to give reasonable results for desktop and mobile.