### PR TITLE
Always use two fingers for translation/rotation/etc

### DIFF
--- a/web/lifecast_res/GestureControlModule.js
+++ b/web/lifecast_res/GestureControlModule.js
@@ -92,15 +92,7 @@ class GestureControlModule {
   }
 
   updateTransformation(world_group_position, mesh_position) {
-    if (this.isLeftPinching && !this.isRightPinching) {
-      let translationDelta = this.leftHandPosition.clone().sub(this.prevLeftHandPosition);
-      this.currentTranslation.add(translationDelta);
-    }
-    else if (this.isRightPinching && !this.isLeftPinching) {
-      let translationDelta = this.rightHandPosition.clone().sub(this.prevRightHandPosition);
-      this.currentTranslation.add(translationDelta);
-    }
-    else if (this.isLeftPinching && this.isRightPinching) {
+    if (this.isLeftPinching && this.isRightPinching) {
       // Use the average of both left and right translation
       let translationDeltaLeft = this.leftHandPosition.clone().sub(this.prevLeftHandPosition);
       let translationDeltaRight = this.rightHandPosition.clone().sub(this.prevRightHandPosition);


### PR DESCRIPTION
This actually feels much better on the Quest 3 because it gets rid of erroneous extra touch gestures.

In the future maybe some kind of in-VR "touch with both hands to move" help message could be useful.